### PR TITLE
fix: Contributing template copyright holder

### DIFF
--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -35,4 +35,4 @@ jobs:
           path-to-document: 'https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CLA.md'
           branch: 'chore/cla-signatures'
           # the below is the list of users who are allowed to sign the CLA without any check
-          allowlist: renovate,dependabot
+          allowlist: "@renovate,dependabot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+## [0.2.1] - 2025-01-13
+
+### Fixed
+
+* fix: Use the copyright's holder name in the contributing template licensing examples
+* docs: Add missing CHANGELOG.md file to the documentation
+* fix: Fix renovate user id in the CLA allowlist
+
 ## [0.2.0] - 2025-01-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tid-xcut/opensource-scaffold",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Scaffolding for open source projects. A CLI tool to create open source repositories tools and resources",
   "packageManager": "pnpm@9.4.0",

--- a/templates/.github/CONTRIBUTING.md
+++ b/templates/.github/CONTRIBUTING.md
@@ -38,18 +38,18 @@ This project adheres to the [Software Package Data Exchange (SPDX)](https://spdx
 This license must be used for all new code, unless the containing project, module or externally-imported codebase uses a different license. If you can't put a header in the file due to its structure, please put it in a LICENSE file in the same directory.
 
 ```
-// SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors. All rights reserved
+// SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 // SPDX-License-Identifier: <%= license %>
 
-# SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors. All rights reserved
+# SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 # SPDX-License-Identifier: <%= license %>
 
 <!--
-   SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors. All rights reserved
+   SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
    SPDX-License-Identifier: <%= license %>
 -->
 
-SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors. All rights reserved
+SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 SPDX-License-Identifier: <%= license %>
 ```
 
@@ -58,18 +58,18 @@ SPDX-License-Identifier: <%= license %>
 This license can be used for test scripts and other short code snippets, at the discretion of the author.
 
 ```
-// SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors
+// SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 // SPDX-License-Identifier: MIT
 
-# SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors
+# SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 # SPDX-License-Identifier: MIT
 
 <!--
-   SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors
+   SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
    SPDX-License-Identifier: MIT
 -->
 
-SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %> and contributors
+SPDX-FileCopyrightText: <%= year %> <%= copyrightHolder %>
 SPDX-License-Identifier: MIT
 ```
 

--- a/templates/.github/workflows/contributor-license-agreement.yml
+++ b/templates/.github/workflows/contributor-license-agreement.yml
@@ -35,4 +35,4 @@ jobs:
           path-to-document: '<%= repositoryUrl %>/blob/main/.github/CLA.md'
           branch: 'chore/cla-signatures'
           # the below is the list of users who are allowed to sign the CLA without any check
-          allowlist: renovate,dependabot
+          allowlist: "@renovate,dependabot"


### PR DESCRIPTION
# Contributing template copyright holder

## Description

### Fixed

* fix: Use the copyright's holder name in the contributing template licensing examples
* docs: Add missing CHANGELOG.md file to the documentation
* fix: Fix renovate user id in the CLA allowlist

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CODE_OF_CONDUCT.md) document
* [x] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
