### PR TITLE
Release v0.2.2

### DIFF
--- a/.github/workflows/contributor-license-agreement.yml
+++ b/.github/workflows/contributor-license-agreement.yml
@@ -34,5 +34,5 @@ jobs:
           signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
           path-to-document: 'https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CLA.md'
           branch: 'chore/cla-signatures'
-          # the below is the list of users who are allowed to sign the CLA without any check
-          allowlist: "@renovate,dependabot"
+          # The below is the list of users who are allowed to sign the CLA without any check
+          allowlist: 'renovatebot,dependabot'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -22,7 +22,7 @@ on:
         required: true
       copyright:
         type: string
-        description: Copyright owner
+        description: Copyright holder
         required: true
       description:
         type: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+## [0.2.2] - 2025-01-14
+
+### Fixed
+
+* fix: Fix MIT license template data. Year and copyright holder name were not being replaced correctly.
+* fix: Fix renovate user id in the CLA allowlist
+
 ## [0.2.1] - 2025-01-13
 
 ### Fixed

--- a/cspell/tech.txt
+++ b/cspell/tech.txt
@@ -1,2 +1,3 @@
 ELIFECYCLE
 opensource
+renovatebot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tid-xcut/opensource-scaffold",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Scaffolding for open source projects. A CLI tool to create open source repositories tools and resources",
   "packageManager": "pnpm@9.4.0",

--- a/templates/.github/workflows/contributor-license-agreement.yml
+++ b/templates/.github/workflows/contributor-license-agreement.yml
@@ -34,5 +34,5 @@ jobs:
           signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
           path-to-document: '<%= repositoryUrl %>/blob/main/.github/CLA.md'
           branch: 'chore/cla-signatures'
-          # the below is the list of users who are allowed to sign the CLA without any check
-          allowlist: "@renovate,dependabot"
+          # The below is the list of users who are allowed to sign the CLA without any check
+          allowlist: 'renovatebot,dependabot'

--- a/templates/license-files/MIT
+++ b/templates/license-files/MIT
@@ -1,4 +1,4 @@
-Copyright {%= year %} {%= copyrightHolder %}
+Copyright <%= year %> <%= copyrightHolder %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
# Release v0.2.2

## Description

### Fixed

* fix: Fix MIT license template data. Year and copyright holder name were not being replaced correctly.
* fix: Fix renovate user id in the CLA allowlist

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/Telefonica/opensource-scaffold/blob/main/.github/CODE_OF_CONDUCT.md) document
* [x] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
